### PR TITLE
reproduce sanity baseurl error

### DIFF
--- a/sanitypathtest/Dockerfile
+++ b/sanitypathtest/Dockerfile
@@ -1,0 +1,29 @@
+ARG NODE_VERSION
+
+FROM node:$NODE_VERSION-alpine as build
+
+ENV NODE_ENV production
+
+ARG NO_MINIFY
+
+WORKDIR /usr/src/app
+
+RUN npm set progress=false
+RUN npm config set depth 0
+
+COPY package*.json ./
+
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=true \
+  npm ci
+
+COPY ./ ./
+
+RUN [ $NO_MINIFY ] && npm run build:non-minified || npm run build
+
+FROM nginx:1.23-alpine AS runtime
+
+COPY --from=build /usr/src/app/dist /usr/share/nginx/html
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 9306

--- a/sanitypathtest/nginx.conf
+++ b/sanitypathtest/nginx.conf
@@ -1,0 +1,33 @@
+server {
+    listen 9306;
+    server_name localhost;
+    port_in_redirect off;
+    access_log off;
+
+    add_header Cache-Control "no-store";
+    add_header Surrogate-Control "no-store";
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        rewrite ^/sanitypathtest/(.*)$ /$1 break;
+        try_files $uri $uri/ /index.html;
+    }
+
+    # in production, the route /sanitypathtest is forwarded
+    # from a reverse proxy - ie. any other path is not available
+    location /static/ {
+        return 404;
+    }
+
+    location /sanitypathtest {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+        root /usr/share/nginx/html;
+    }
+}

--- a/sanitypathtest/package.json
+++ b/sanitypathtest/package.json
@@ -9,7 +9,9 @@
     "start": "sanity start",
     "build": "sanity build",
     "deploy": "sanity deploy",
-    "deploy-graphql": "sanity graphql deploy"
+    "deploy-graphql": "sanity graphql deploy",
+    "build:docker": "DOCKER_BUILDKIT=1 docker build --secret id=npmrc,src=$HOME/.npmrc . -t sanitypathtest --build-arg NO_MINIFY=1 --build-arg NODE_VERSION=18",
+    "start:docker": "docker run -p 3333:9306 sanitypathtest"
   },
   "keywords": [
     "sanity"

--- a/sanitypathtest/sanity.cli.ts
+++ b/sanitypathtest/sanity.cli.ts
@@ -3,6 +3,9 @@ import {defineCliConfig} from 'sanity/cli'
 export default defineCliConfig({
   api: {
     projectId: 'emt9r934',
-    dataset: 'production'
-  }
+    dataset: 'production',
+  },
+  vite: (prevConfig) => {
+    return {...prevConfig, build: {...prevConfig.build, assetsDir: 'mynamespace'}}
+  },
 })


### PR DESCRIPTION
Added Dockerfile and build/start scripts to showcase the error we're experiencing

To run it:
- cd sanitypathttest
- npm ci
- npm run build:docker
- npm run start:docker
- open http://localhost:3333/mynamespace/desk/

I don't have access to the project/dataset, but after logging in I get the following results in my network tab

<img width="540" alt="image" src="https://user-images.githubusercontent.com/1043634/224470987-2540872f-f5cd-42bd-b6ec-94633ab1fe56.png">

This is due to the fact that all favicons are referenced to a `/static` basepath - which is not available when the app is running behind a reverse proxy (ie. the frontend doesn't have access to files hosted on `/static/` - only `/mynamespace`

<img width="622" alt="image" src="https://user-images.githubusercontent.com/1043634/224471043-75bf4e7b-7976-41dc-b0ad-f8483a99104f.png">

The app itself on the other hand (.js) is available on the path - as instructed to vite

<img width="527" alt="image" src="https://user-images.githubusercontent.com/1043634/224471067-7afe027c-1494-4b49-8f3b-1aa4f1594e86.png">

If we change the cli config either as such
```js
  project: {
    basePath: '/mynamespace',
  },
```

or 

```js
  project: {
    basePath: '/mynamespace',
  },
  vite: (prevConfig) => {
    return {
      ...prevConfig,
      build: {
        ...prevConfig.build,
        assetsDir: 'mynamespace',
      },
    };
  },
```

the hosting errors are reversed: the favicons will be hosted from `/mynamespace` - but the script file is hosted from `/static`
```js